### PR TITLE
fix(commitizen): scope working directory only for specific steps

### DIFF
--- a/.github/workflows/bumpversion.yaml
+++ b/.github/workflows/bumpversion.yaml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   bump-version:
-    defaults:
-      run:
-        working-directory: ./images
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     name: "Bump version and create changelog with commitizen"
@@ -21,12 +18,14 @@ jobs:
           fetch-depth: 0
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
+        working-directory: ./images
         with:
           github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           branch: "cz-version-${{ github.run_number }}"
           changelog_increment_filename: body.md
       - name: Release
         uses: softprops/action-gh-release@v1
+        working-directory: ./images
         with:
           body_path: "body.md"
           tag_name: "${{ env.REVISION }}"

--- a/.github/workflows/bumpversion.yaml
+++ b/.github/workflows/bumpversion.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'images/**'
 
 jobs:
   bump-version:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,12 @@ on:
     - cron: '16 0 * * 1'
   push:
     branches: [ main ]
+    paths:
+      - 'images/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'images/**'
 
 concurrency:
   group: ${{ github.head_ref || github.ref  }}


### PR DESCRIPTION
I think the previous version of the workflow set the working directory, checked out the repo into it, and then still worked on the git root. I actually wanted the steps themselves to run in the subdirectory.